### PR TITLE
Add sf cpp boston parsing

### DIFF
--- a/R/bikedata-files.R
+++ b/R/bikedata-files.R
@@ -122,8 +122,9 @@ get_nabsa_files <- function (city)
 #' @noRd
 get_bike_files <- function (city)
 {
-    aws_cities <- c ('ny', 'dc', 'bo')
-    buckets <- c ('tripdata', 'capitalbikeshare-data', 'hubway-data')
+    aws_cities <- c ('ny', 'dc', 'bo', 'sf')
+    buckets <- c ('tripdata', 'capitalbikeshare-data', 
+                  'hubway-data', 'fordgobike-data')
     nabsa_cities <- c ('la', 'ph')
 
     if (city %in% aws_cities)

--- a/R/database-stats.R
+++ b/R/database-stats.R
@@ -495,15 +495,16 @@ bike_daily_trips <- function (bikedb, city, station, member, birth_year, gender,
 bike_demographic_data <- function ()
 {
     dat <- data.frame (city = c ('bo', 'ch', 'dc', 'la', 'lo',
-                                 'mn', 'ny', 'ph'),
+                                 'mn', 'ny', 'ph', 'sf'),
                        city_name = c ('Boston', 'Chicago', 'Washington DC',
                                       'Los Angeles', 'London', 'Minneapolis',
-                                      'New York', 'Philadelphia'),
+                                      'New York', 'Philadelphia', 'Bay Area'),
                        bike_system = c ('Hubway', 'Divvy', 'CapitalBikeShare',
                                         'Metro', 'Santander', 'NiceRide',
-                                        'Citibike', 'Indego'),
+                                        'Citibike', 'Indego','FordGoBike'),
                        demographic_data = c (TRUE, TRUE, FALSE, FALSE,
-                                             FALSE, TRUE, TRUE, FALSE),
+                                             FALSE, TRUE, TRUE, FALSE,
+                                             TRUE),
                        stringsAsFactors = FALSE)
 
     return (dat)

--- a/R/store-bikedata.R
+++ b/R/store-bikedata.R
@@ -116,9 +116,9 @@ store_bikedata <- function (bikedb, city, data_dir, dates = NULL, quiet = FALSE)
     {
         if (!quiet)
         {
-            if (length (city) == 1 & ci != 'lo')
+            if (length (city) == 1 & (ci != 'lo' & ci != 'sf'))
                 message ('Unzipping raw data files ...')
-            else if (ci != 'lo') # mostly csv files that don't need unzipping
+            else if (ci != 'lo' & ci != 'sf') # mostly csv files that don't need unzipping
                 message ('Unzipping raw data files for ', ci, ' ...')
         }
         if (ci == 'ch')
@@ -137,7 +137,7 @@ store_bikedata <- function (bikedb, city, data_dir, dates = NULL, quiet = FALSE)
                 nf <- rcpp_import_to_file_table (bikedb,
                                                  basename (flists$flist_zip),
                                                  ci, nf)
-            if (ci %in% c('bo', 'lo') & length (flists$flist_csv) > 0)
+            if (ci %in% c('bo', 'lo', 'sf') & length (flists$flist_csv) > 0)
                 nf <- rcpp_import_to_file_table (bikedb,
                                                  basename (flists$flist_csv),
                                                  ci, nf)
@@ -356,6 +356,8 @@ get_flist_city <- function (data_dir, bikedb, city)
         index <- which (grepl ('nice', flist, ignore.case = TRUE))
     else if (any (city == 'ph'))
         index <- which (grepl ('indego', flist, ignore.case = TRUE))
+    else if (any (city == 'sf'))
+        index <- which (grepl ('fordgobike', flist, ignore.case = TRUE))
 
     ret <- NULL
     if (length (index) > 0)
@@ -415,7 +417,7 @@ bike_unzip_files <- function (data_dir, bikedb, city, dates)
 
     # Some cities issue non-compressed files (recent London files; annual Boston
     # dumps for 2011-14)
-    if (city %in% c ('bo', 'lo') && length (fcsv) > 0)
+    if (city %in% c ('bo', 'lo', 'sf') && length (fcsv) > 0)
     {
         flist_csv <- get_new_datafiles (bikedb, fcsv)
         if (city == 'bo') # Also has station files

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,10 +27,11 @@ convert_city_names <- function (city)
                      'la', 'me', # LA metro
                      'lo', 'sa', # london santander
                      'ph', 'in', # philly indego
-                     'mn', 'mi') # minneapolis/st.paul nice ride
+                     'mn', 'mi',
+                     'by', 'fd', 'ok','sf','sj') # minneapolis/st.paul nice ride
     city_code <- c ('ny', 'ny', 'ny', 'bo', 'bo', 'ch', 'ch',
                     'dc', 'dc', 'dc', 'la', 'la', 'lo', 'lo', 'ph', 'ph',
-                    'mn', 'mn')
+                    'mn', 'mn','sf','sf','sf','sf','sf')
     city_code <- city_code [pmatch (city, city_names)]
 
     if (length (indx_lo) > 0)

--- a/README.Rmd
+++ b/README.Rmd
@@ -40,6 +40,7 @@ bikes and of docking stations, are:
 City | Hire Bicycle System | Number of Bicycles | Number of Docking Stations
 --- | --- | --- | ---
 London, U.K. | [Santander Cycles](https://tfl.gov.uk/modes/cycling/santander-cycles) | 13,600 | 839
+San Francisco Bay Area, U.S.A. | [Ford GoBike](https://www.fordgobike.com/)  | 7,000 | 540 
 New York City NY, U.S.A. | [citibike](https://www.citibikenyc.com/) | 7,000 | 458
 Chicago IL, U.S.A. | [Divvy](https://www.divvybikes.com/) | 5,837 | 576
 Washingon DC, U.S.A. | [Capital BikeShare](https://www.capitalbikeshare.com/) | 4,457 | 406

--- a/src/read-city-files.cpp
+++ b/src/read-city-files.cpp
@@ -939,7 +939,7 @@ unsigned int read_one_line_mn (sqlite3_stmt * stmt, char * line)
 
 //' read_one_line_sf
 //'
-//' This function might work. 
+//' This function tokenizes strings from one line of san francisco bay area's bikeshare data
 //' 
 //' @param stmt An sqlit3 statement to be assembled by reading the line of data
 //' @param line Line of data read from citibike file

--- a/src/read-city-files.cpp
+++ b/src/read-city-files.cpp
@@ -992,11 +992,17 @@ unsigned int read_one_line_sf (sqlite3_stmt * stmt, char * line,
     if (user_type == "Subscriber")
     {
         birth_year = strtokm (nullptr, delim);
+        boost::replace_all (birth_year, "\n","");
+        boost::replace_all (birth_year, "\"", "");
         gender = strtokm (nullptr, delim_nq_q);
         boost::replace_all (gender, "\n","");
         boost::replace_all (gender, "\"", "");
-        boost::replace_all (birth_year, "\n","");
-        boost::replace_all (birth_year, "\"", "");
+        if (gender == "Female")
+            gender = "2";
+        else if (gender == "Male")
+            gender = "1";
+        else
+            gender = "0";
         user_type = "1";
     } else
         user_type = "0";

--- a/src/read-city-files.cpp
+++ b/src/read-city-files.cpp
@@ -970,6 +970,8 @@ unsigned int read_one_line_sf (sqlite3_stmt * stmt, char * line,
     std::string in_line2 = line;
     boost::replace_all (in_line2, "\\N","\"\"");
 
+// from read_one_boston
+
     std::string duration = strtokm (&in_line2[0u], delim_nq_q);
     std::string start_time = strtokm (nullptr, delim_q_q); // no need to convert
     std::string end_time = strtokm (nullptr, delim_q_nq); 
@@ -986,6 +988,26 @@ unsigned int read_one_line_sf (sqlite3_stmt * stmt, char * line,
     std::string end_station_lat = strtokm (nullptr, delim);
     std::string end_station_lon = strtokm (nullptr, delim);
 
+// end from read_one_boston
+
+// select from read_one_nabsa
+
+    unsigned int ret = 0;
+
+    start_station_id = city + start_station_id;
+    end_station_id = city + end_station_id;
+
+    if (stationqry->count(end_station_id) == 0 && ret == 0 &&
+            end_station_lat != " " && end_station_lon != " " &&
+            end_station_lat != "0" && end_station_lon != "0")
+    {
+        std::string end_station_name = "";
+        (*stationqry)[end_station_id] = "(\'" + city + "\',\'" +
+            end_station_id + "\',\'\'," + 
+            end_station_lat + "," + end_station_lon + ")";
+    }
+// end from read_one_nabsa
+
     std::string bike_number = strtokm (nullptr, delim_nq_q);
     std::string user_type = strtokm (nullptr, delim_q_nq);
     std::string birth_year = "", gender = "";
@@ -997,12 +1019,14 @@ unsigned int read_one_line_sf (sqlite3_stmt * stmt, char * line,
         gender = strtokm (nullptr, delim_nq_q);
         boost::replace_all (gender, "\n","");
         boost::replace_all (gender, "\"", "");
+        //from read_one_chicago
         if (gender == "Female")
             gender = "2";
         else if (gender == "Male")
             gender = "1";
         else
             gender = "0";
+        //end from read_one_chicago
         user_type = "1";
     } else
         user_type = "0";
@@ -1017,6 +1041,5 @@ unsigned int read_one_line_sf (sqlite3_stmt * stmt, char * line,
     sqlite3_bind_text(stmt, 9, birth_year.c_str(), -1, SQLITE_TRANSIENT); 
     sqlite3_bind_text(stmt, 10, gender.c_str(), -1, SQLITE_TRANSIENT); 
 
-    unsigned int ret = 0;
     return ret;
 }

--- a/src/read-city-files.h
+++ b/src/read-city-files.h
@@ -59,3 +59,8 @@ unsigned int read_one_line_nabsa (sqlite3_stmt * stmt, char * line,
         std::string city);
 
 unsigned int read_one_line_mn (sqlite3_stmt * stmt, char * line);
+
+unsigned int read_one_line_sf (sqlite3_stmt * stmt, char * line,
+        std::map <std::string, std::string> * stationqry,
+        std::string city);
+

--- a/src/sqlite3db-add-data.cpp
+++ b/src/sqlite3db-add-data.cpp
@@ -141,6 +141,8 @@ int rcpp_import_to_trip_table (const char* bikedb,
                 rc = read_one_line_nabsa (stmt, in_line, &stationqry, city);
             else if (city == "mn")
                 rc = read_one_line_mn (stmt, in_line);
+            else if (city == "sf")
+                rc = read_one_line_sf (stmt, in_line, &stationqry, city);
 
             if (rc == 0) // only != 0 for LA, London, Boston, and MN
             {
@@ -155,7 +157,7 @@ int rcpp_import_to_trip_table (const char* bikedb,
     sqlite3_exec(dbcon, "END TRANSACTION", nullptr, nullptr, &zErrMsg);
     sqlite3_free (zErrMsg);
 
-    if (city == "ny" || city == "la" || city == "ph")
+    if (city == "ny" || city == "la" || city == "ph" || city == "sf")
         import_to_station_table (dbcon, stationqry);
 
     rc = static_cast <size_t> (sqlite3_close_v2 (dbcon));

--- a/src/sqlite3db-add-data.cpp
+++ b/src/sqlite3db-add-data.cpp
@@ -143,7 +143,6 @@ int rcpp_import_to_trip_table (const char* bikedb,
                 rc = read_one_line_mn (stmt, in_line);
             else if (city == "sf")
                 rc = read_one_line_sf (stmt, in_line, &stationqry, city);
-
             if (rc == 0) // only != 0 for LA, London, Boston, and MN
             {
                 ntrips++;
@@ -157,7 +156,7 @@ int rcpp_import_to_trip_table (const char* bikedb,
     sqlite3_exec(dbcon, "END TRANSACTION", nullptr, nullptr, &zErrMsg);
     sqlite3_free (zErrMsg);
 
-    if (city == "ny" || city == "la" || city == "ph")
+    if (city == "ny" || city == "la" || city == "ph" || city == "sf")
         import_to_station_table (dbcon, stationqry);
 
     rc = static_cast <size_t> (sqlite3_close_v2 (dbcon));

--- a/src/sqlite3db-add-data.cpp
+++ b/src/sqlite3db-add-data.cpp
@@ -157,7 +157,7 @@ int rcpp_import_to_trip_table (const char* bikedb,
     sqlite3_exec(dbcon, "END TRANSACTION", nullptr, nullptr, &zErrMsg);
     sqlite3_free (zErrMsg);
 
-    if (city == "ny" || city == "la" || city == "ph" || city == "sf")
+    if (city == "ny" || city == "la" || city == "ph")
         import_to_station_table (dbcon, stationqry);
 
     rc = static_cast <size_t> (sqlite3_close_v2 (dbcon));


### PR DESCRIPTION
hey @mpadge this seems like a solution/addition for sf with a potential bug introduction. totally understand that you'll want to understand the bug below more before merge. 

### Solution 

You can do the following now:

```
library(bikedata)
data_dir <- tempdir()
bikedb <- file.path (data_dir, 'bikedb')
dl_bikedata (city = 'la', data_dir = data_dir)
dl_bikedata (city = 'sf', data_dir = data_dir)
store_bikedata (data_dir = data_dir, bikedb = bikedb, city='la')
store_bikedata (data_dir = data_dir, bikedb = bikedb, city='sf')
```
and you get stations and trips for la. 

you can also then load other cities e.g. boston:
```
dl_bikedata (city = 'bo', data_dir = data_dir)
store_bikedata (data_dir = data_dir, bikedb = bikedb, city='bo')
```

### Bug

unfortunately, i did notice that if you do this:
```
data_dir <- tempdir()
bikedb <- file.path (data_dir, 'bikedb')
dl_bikedata (city = 'bo', data_dir = data_dir)
dl_bikedata (city = 'sf', data_dir = data_dir)
store_bikedata (data_dir = data_dir, bikedb = bikedb, city='sf')
```

Then store bikedata starts to try to load 11 CSV files. There are only 4 for 'sf' so far. 

Then the R session crashes. It seems that store_bikedata looks for all CSV files. 

I guess there are a few options here: 

1) fix the way that store_bikedata works on CSV's?
2) tell people specifically not to download a bunch of csv's for 2 providers and then just process 1?

probably (1) is ideal. i'll look into it a bit. 




