### PR TITLE
lat-lng station patch

### DIFF
--- a/src/read-station-files.cpp
+++ b/src/read-station-files.cpp
@@ -35,7 +35,7 @@ int stns::import_to_station_table (sqlite3 * dbcon,
 
     // http://stackoverflow.com/questions/19337029/insert-if-not-exists-statement-in-sqlite
     std::string fullstationqry = "INSERT OR IGNORE INTO stations "
-        "(city, stn_id, name, latitude, longitude) VALUES ";
+        "(city, stn_id, name, longitude, latitude) VALUES ";
     fullstationqry += stationqry.begin ()->second;
     for (auto thisstation = std::next (stationqry.begin ());
             thisstation != stationqry.end (); ++thisstation)


### PR DESCRIPTION
seems like our old friends long and lat were inverted in a query. 

i made this change and then rebuilt and checked against sf, lo, and ny using the following:

```
check_station_location <- function(cityname, long_check) {
  data_dir=tempdir()
  bikedb <- file.path (data_dir, paste0('db',cityname))
  dl_bikedata(cityname,dates=201802:201803, data_dir = data_dir)
  store_bikedata(city=cityname,data_dir=data_dir,bikedb)
  stations <- bike_stations(bikedb)
  m_lon = median(stations$longitude)
  check = (m_lon > (long_check[1]) & 
             m_lon < (long_check[2]))
  return(check)
}
```

```
check_station_location('lo',c(-10,10))
```

unfortunately the test above is not robust against introducing a new city. the following seems to re-load london. 

```
check_station_location('sf',c(-100,-130))
```

is there a better way to instantiate a blank tempdir for the data without requiring a user to input y/n for download and directory creation? 