### PR TITLE
Fix NULL values handling in nyc data

### DIFF
--- a/src/read-city-files.cpp
+++ b/src/read-city-files.cpp
@@ -67,9 +67,15 @@ unsigned int city::read_one_line_generic (sqlite3_stmt * stmt, char * line,
 
     std::string linestr = line;
     if (headers.terminal_quote)
+    {
+        boost::replace_all (linestr, "NULL", "\"\"");
         boost::replace_all (linestr, "\\N", "\"\"");
+    }
     else
+    {
+        boost::replace_all (linestr, "NULL", "");
         boost::replace_all (linestr, "\\N", "");
+    }
 
     std::vector <std::string> values (num_db_fields);
     std::fill (values.begin (), values.end (), "\"\"");

--- a/src/read-city-files.cpp
+++ b/src/read-city-files.cpp
@@ -67,15 +67,14 @@ unsigned int city::read_one_line_generic (sqlite3_stmt * stmt, char * line,
 
     std::string linestr = line;
     if (headers.terminal_quote)
-    {
-        boost::replace_all (linestr, "NULL", "\"\"");
         boost::replace_all (linestr, "\\N", "\"\"");
-    }
     else
-    {
-        boost::replace_all (linestr, "NULL", "");
         boost::replace_all (linestr, "\\N", "");
-    }
+    
+    // In NYC data files starting from Aug 2018 onwards missing values
+    // are marked as NULL: https://github.com/ropensci/bikedata/issues/96
+    if (utils::strfound (city, "ny"))
+        boost::replace_all (linestr, "NULL", "");
 
     std::vector <std::string> values (num_db_fields);
     std::fill (values.begin (), values.end (), "\"\"");


### PR DESCRIPTION
This is a patch regarding #96 . I looked around the code and noticed the part where `\N` (the previous way how missing values where marked in the nyc data) characters are removed. I added lines removing "NULL" and this seems to be fixing the issue :D